### PR TITLE
improve compatibility with external ebuilds

### DIFF
--- a/net-misc/curl/curl-7.60.0.ebuild
+++ b/net-misc/curl/curl-7.60.0.ebuild
@@ -29,7 +29,7 @@ SLOT="0"
 KEYWORDS="amd64 arm arm64"
 IUSE_A=(
 	curldebug +largefile libgcc +rt +symbol-hiding versioned-symbols static-libs test threads
-	
+
 	#improve compatibility with external packages referencing these official use flags
 	curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss curl_ssl_openssl
 

--- a/net-misc/curl/curl-7.60.0.ebuild
+++ b/net-misc/curl/curl-7.60.0.ebuild
@@ -128,12 +128,12 @@ REQUIRED_USE_A=(
 	"protocol_scp?		( || ( libssh2 libssh ) )"
 	"protocol_sftp?		( || ( libssh2 libssh ) )"
 	#ensure these use flags have the intended effect
-	"curl_ssl_axtls? 	( ssl_axtls ) !curl_ssl_axtls? ( !ssl_axtls )"
-	"curl_ssl_gnutls? 	( ssl_gnutls ) !curl_ssl_gnutls? ( !ssl_gnutls )"
-	"curl_ssl_libressl? 	( ssl_libressl ) !curl_ssl_libressl? ( !ssl_libressl )"
-	"curl_ssl_mbedtls? 	( ssl_mbedtls ) !curl_ssl_mbedtls? ( !ssl_mbedtls )"
-	"curl_ssl_nss? 		( ssl_nss ) !curl_ssl_nss? ( !ssl_nss )"
-	"curl_ssl_openssl? 	( ssl_openssl ) !curl_ssl_openssl? ( !ssl_openssl )"
+	"curl_ssl_axtls? 	( ssl_axtls )"
+	"curl_ssl_gnutls? 	( ssl_gnutls )"
+	"curl_ssl_libressl? 	( ssl_libressl )"
+	"curl_ssl_mbedtls? 	( ssl_mbedtls )"
+	"curl_ssl_nss? 		( ssl_nss )"
+	"curl_ssl_openssl? 	( ssl_openssl )"
 )
 
 inherit arrays

--- a/net-misc/curl/curl-7.60.0.ebuild
+++ b/net-misc/curl/curl-7.60.0.ebuild
@@ -29,6 +29,9 @@ SLOT="0"
 KEYWORDS="amd64 arm arm64"
 IUSE_A=(
 	curldebug +largefile libgcc +rt +symbol-hiding versioned-symbols static-libs test threads
+	
+	#improve compatibility with external packages referencing these official use flags
+	curl_ssl_axtls curl_ssl_gnutls curl_ssl_libressl curl_ssl_mbedtls curl_ssl_nss curl_ssl_openssl
 
 	libcurl-option manual +verbose
 
@@ -124,6 +127,13 @@ REQUIRED_USE_A=(
 	"protocol_smtps?	( protocol_smtp ssl )"
 	"protocol_scp?		( || ( libssh2 libssh ) )"
 	"protocol_sftp?		( || ( libssh2 libssh ) )"
+	#ensure these use flags have the intended effect
+	"curl_ssl_axtls? 	( ssl_axtls ) !curl_ssl_axtls? ( !ssl_axtls )"
+	"curl_ssl_gnutls? 	( ssl_gnutls ) !curl_ssl_gnutls? ( !ssl_gnutls )"
+	"curl_ssl_libressl? 	( ssl_libressl ) !curl_ssl_libressl? ( !ssl_libressl )"
+	"curl_ssl_mbedtls? 	( ssl_mbedtls ) !curl_ssl_mbedtls? ( !ssl_mbedtls )"
+	"curl_ssl_nss? 		( ssl_nss ) !curl_ssl_nss? ( !ssl_nss )"
+	"curl_ssl_openssl? 	( ssl_openssl ) !curl_ssl_openssl? ( !ssl_openssl )"
 )
 
 inherit arrays


### PR DESCRIPTION
uses the suggested idea from #240, making sure to include comments explaining why the sections exist. winssl is excluded as it did not seem to have an associated use flag.